### PR TITLE
feat: Add a Favorite node group in tools menu

### DIFF
--- a/modules/settings/src/main/kotlin/dev/turingcomplete/intellijdevelopertoolsplugin/settings/DeveloperToolConfiguration.kt
+++ b/modules/settings/src/main/kotlin/dev/turingcomplete/intellijdevelopertoolsplugin/settings/DeveloperToolConfiguration.kt
@@ -30,6 +30,20 @@ class DeveloperToolConfiguration(
   var isResetting = false
     private set
 
+  private val favoriteProperty = register(
+        "isFavorite",
+        false,
+        PropertyType.CONFIGURATION
+    )
+
+    var isFavorite: Boolean
+        get() = favoriteProperty.get()
+        set(value) {
+            favoriteProperty.set(value)
+        }
+
+
+
   // -- Initialization ------------------------------------------------------ //
   // -- Exposed Methods ----------------------------------------------------- //
 

--- a/modules/tools/ui/src/main/kotlin/dev/turingcomplete/intellijdevelopertoolsplugin/tool/ui/frame/menu/DeveloperToolNode.kt
+++ b/modules/tools/ui/src/main/kotlin/dev/turingcomplete/intellijdevelopertoolsplugin/tool/ui/frame/menu/DeveloperToolNode.kt
@@ -34,6 +34,15 @@ class DeveloperToolNode(
   val developerTools: List<DeveloperToolContainer>
     get() = _developerTools
 
+  var isFavorite: Boolean
+    get() = settings.getDeveloperToolConfigurations(developerToolId).firstOrNull()?.isFavorite ?: false
+    set(value) {
+        settings.getDeveloperToolConfigurations(developerToolId).firstOrNull()?.let {
+          it.isFavorite = value
+        }
+    }
+
+
   // -- Initialization ------------------------------------------------------ //
   // -- Exposed Methods ----------------------------------------------------- //
 


### PR DESCRIPTION
Add a favorite toggle button next to each tool panel's title.
If any favorite tools are registered, displayed a "Favorite" node in top of the tools list menu.